### PR TITLE
add gracenote id for channels dvr epg loading to m3u

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -279,8 +279,8 @@ async fn tuner_m3u<T: 'static + StationProvider>(req: HttpRequest) -> HttpRespon
         };
 
         builder.append(format!(
-            "#EXTINF:-1 channel-id=\"{}\" tvg-id=\"channel.{}\" tvg-name=\"{}\" tvg-logo=\"{}\" tvg-chno=\"{}\" group-title=\"{}\", {}",
-            station.id, station.id, call_sign, logo, channel, groups, tvg_name
+            "#EXTINF:-1 channel-id=\"{}\" tvg-id=\"channel.{}\" tvg-name=\"{}\" tvg-logo=\"{}\" tvg-chno=\"{}\" tvc-guide-stationid=\"{}\" group-title=\"{}\", {}",
+            station.id, station.id, call_sign, logo, channel, station.stationId, groups, tvg_name
         ));
 
         let url = format!("http://{}/watch/{}.m3u", &host, &station.id);


### PR DESCRIPTION
this adds the tvc-guide-stationid to the generated m3u, which enables channels dvr to pull the guide data directly from their gracenote db rather than having to use the locast epg.